### PR TITLE
Add multipliers

### DIFF
--- a/binding/python/eigen_qld/c_eigen_qld.pxd
+++ b/binding/python/eigen_qld/c_eigen_qld.pxd
@@ -28,6 +28,8 @@ cdef extern from "<eigen-qld/QLD.h>" namespace "Eigen":
 
     const c_eigen.VectorXd& result()
 
+    const c_eigen.VectorXd& multipliers()
+
     bool solve(const c_eigen.MatrixXd&, const c_eigen.VectorXd&,
         const c_eigen.MatrixXd&, const c_eigen.VectorXd&,
         const c_eigen.MatrixXd&, const c_eigen.VectorXd&,

--- a/binding/python/eigen_qld/eigen_qld.pyx
+++ b/binding/python/eigen_qld/eigen_qld.pyx
@@ -38,6 +38,8 @@ cdef class QLD(object):
     self.impl.problem(nrvar, nreq, nrineq)
   def result(self):
     return eigen.VectorXdFromC(self.impl.result())
+  def multipliers(self):
+    return eigen.VectorXdFromC(self.impl.multipliers())
   def solve(self, eigen.MatrixXd Q, eigen.VectorXd C,
                   eigen.MatrixXd Aeq, eigen.VectorXd Beq,
                   eigen.MatrixXd Aineq, eigen.VectorXd Bineq,

--- a/src/QLD.cpp
+++ b/src/QLD.cpp
@@ -106,5 +106,9 @@ const VectorXd& QLD::result() const
 	return X_;
 }
 
+const VectorXd& QLD::multipliers() const
+{
+	return U_;
+}
 
 } // namespace Eigen

--- a/src/eigen-qld/QLD.h
+++ b/src/eigen-qld/QLD.h
@@ -57,6 +57,9 @@ public:
 
 	EIGEN_QLD_API const VectorXd& result() const;
 
+	/** Return the lagrange multipliers associated with results **/
+	EIGEN_QLD_API const VectorXd& multipliers() const;
+
 	template <typename MatObj, typename VecObj,
 						typename MatEq, typename VecEq,
 						typename MatIneq, typename VecIneq,


### PR DESCRIPTION
Add an accessor for the `U_` object that represents the Lagrange multipliers of the constraints.

This PR is based on #6 but does not depend on it (could be rebased on master).