### PR TITLE
Fix the use of leading dimension (NMAX and MMAX) and add documentation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -85,10 +85,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 150
 PenaltyReturnTypeOnItsOwnLine: 300
 PointerAlignment: Middle
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true

--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -1,4 +1,3 @@
-INPUT                  = @CMAKE_SOURCE_DIR@/include
-IMAGE_PATH             = @CMAKE_SOURCE_DIR@/doc/pictures
+INPUT                  = @CMAKE_SOURCE_DIR@/src/eigen-qld
 FILE_PATTERNS          = *.h *.idl
 

--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -1,3 +1,4 @@
 INPUT                  = @CMAKE_SOURCE_DIR@/src/eigen-qld
+USE_MDFILE_AS_MAINPAGE = @CMAKE_SOURCE_DIR@/README.md
 FILE_PATTERNS          = *.h *.idl
 

--- a/src/QLD.cpp
+++ b/src/QLD.cpp
@@ -12,7 +12,7 @@ namespace Eigen
 
 QLD::QLD() : A_(), B_(), fdOut_(0), verbose_(false), fail_(0), U_(), WAR_(), IWAR_() {}
 
-QLD::QLD(int nrvar, int nreq, int nrineq, bool verbose, int ldq)
+QLD::QLD(int nrvar, int nreq, int nrineq, int ldq, bool verbose)
 : A_(), B_(), fdOut_(0), verbose_(verbose ? 1 : 0), fail_(0), U_(), WAR_(), IWAR_()
 {
   problem(nrvar, nreq, nrineq, ldq);
@@ -47,7 +47,7 @@ void QLD::problem(int nrvar, int nreq, int nrineq, int ldq)
 {
   int nrconstr = nreq + nrineq;
 
-  if(ldq < 0) ldq = nrvar;
+  if(ldq < nrvar) ldq = nrvar;
 
   assert(ldq >= nrvar);
 

--- a/src/QLD.cpp
+++ b/src/QLD.cpp
@@ -12,10 +12,10 @@ namespace Eigen
 
 QLD::QLD() : A_(), B_(), fdOut_(0), verbose_(false), fail_(0), U_(), WAR_(), IWAR_() {}
 
-QLD::QLD(int nrvar, int nreq, int nrineq, bool verbose)
+QLD::QLD(int nrvar, int nreq, int nrineq, bool verbose, int ldq, int lda)
 : A_(), B_(), fdOut_(0), verbose_(verbose ? 1 : 0), fail_(0), U_(), WAR_(), IWAR_()
 {
-  problem(nrvar, nreq, nrineq);
+  problem(nrvar, nreq, nrineq, ldq, lda);
 }
 
 void QLD::fdOut(int fd)
@@ -43,16 +43,23 @@ int QLD::fail() const
   return fail_;
 }
 
-void QLD::problem(int nrvar, int nreq, int nrineq)
+void QLD::problem(int nrvar, int nreq, int nrineq, int ldq, int lda)
 {
   int nrconstr = nreq + nrineq;
 
-  int MMAX = nrconstr == 0 ? 1 : nrconstr;
-  // nrvar can't be == 0 so NMAX == nrvar
-  int NMAX = nrvar;
+  if (ldq<0)
+    ldq = nrvar;
+  if (lda<0)
+    lda = nrconstr;
 
-  A_.resize(MMAX, NMAX);
-  B_.resize(MMAX);
+  assert(ldq>=nrvar);
+  assert(lda>=nrconstr);
+
+  int MMAX = lda == 0 ? 1 : lda;
+  int NMAX = ldq == 0 ? 1 : ldq;
+
+  A_.resize(nrconstr, nrvar);
+  B_.resize(nrconstr);
 
   X_.resize(nrvar);
 

--- a/src/QLD.cpp
+++ b/src/QLD.cpp
@@ -12,10 +12,10 @@ namespace Eigen
 
 QLD::QLD() : A_(), B_(), fdOut_(0), verbose_(false), fail_(0), U_(), WAR_(), IWAR_() {}
 
-QLD::QLD(int nrvar, int nreq, int nrineq, bool verbose, int ldq, int lda)
+QLD::QLD(int nrvar, int nreq, int nrineq, bool verbose, int ldq)
 : A_(), B_(), fdOut_(0), verbose_(verbose ? 1 : 0), fail_(0), U_(), WAR_(), IWAR_()
 {
-  problem(nrvar, nreq, nrineq, ldq, lda);
+  problem(nrvar, nreq, nrineq, ldq);
 }
 
 void QLD::fdOut(int fd)
@@ -43,19 +43,15 @@ int QLD::fail() const
   return fail_;
 }
 
-void QLD::problem(int nrvar, int nreq, int nrineq, int ldq, int lda)
+void QLD::problem(int nrvar, int nreq, int nrineq, int ldq)
 {
   int nrconstr = nreq + nrineq;
 
-  if (ldq<0)
-    ldq = nrvar;
-  if (lda<0)
-    lda = nrconstr;
+  if(ldq < 0) ldq = nrvar;
 
-  assert(ldq>=nrvar);
-  assert(lda>=nrconstr);
+  assert(ldq >= nrvar);
 
-  int MMAX = lda == 0 ? 1 : lda;
+  int MMAX = nrconstr == 0 ? 1 : nrconstr;
   int NMAX = ldq == 0 ? 1 : ldq;
 
   A_.resize(nrconstr, nrvar);

--- a/src/eigen-qld/QLD.h
+++ b/src/eigen-qld/QLD.h
@@ -41,27 +41,97 @@ extern "C" int ql_(const int * m,
                    int * iwar,
                    int * liwar);
 
+/** \brief A wrapper of the ql algorithm by Professor Schittkowski */
 class QLD
 {
 public:
+  /** Create a solver without allocating memory.
+   * A call to QLD::problem will be necessary before calling QLD::solve
+   */
   EIGEN_QLD_API QLD();
-  EIGEN_QLD_API QLD(int nrvar, int nreq, int nrineq, bool verbose = false, int ldq=-1, int lda=-1);
 
+  /** Create a solver and allocate the memory necessary to solve a problem with the given dimensions.
+   * See also QLD::problem
+   */
+  EIGEN_QLD_API QLD(int nrvar, int nreq, int nrineq, bool verbose = false, int ldq = -1);
+
+  /** Specify a file number for output (Fortran unit specification).*/
   EIGEN_QLD_API void fdOut(int fd);
+  /** Get the file number used for output*/
   EIGEN_QLD_API int fdOut() const;
 
+  /** Specify if QLD must generate outputs or not.*/
   EIGEN_QLD_API void verbose(bool v);
+  /** Check if QLD must generate outputs or not.*/
   EIGEN_QLD_API bool verbose() const;
 
+  /** Return the fail code of QLD. 0 means succes.*/
   EIGEN_QLD_API int fail() const;
 
-  EIGEN_QLD_API void problem(int nrvar, int nreq, int nrineq, int ldq=-1, int lda=-1);
+  /** Allocate the memory necessary to solve a problem with the given dimensions.
+   * \param nrvar Size of the variable vector \f$x\f$.
+   * \param nreq Number of equality constraints, i.e. the row size of \f$A_{eq}\f$.
+   * \param nrineq Number of inequality constraints, i.e. the row size of \f$A_{ineq}\f$.
+   * \param ldq Leading dimension of the matrix \f$Q\f$ (see below). If negative,
+   * \p nrvar will be used instead (which is the default case).
+   *
+   * \note For a column-major matrix (which is the default case in Eigen and what QLD
+   * is expecting), the matrix values are stored in a simple, 1-d array, one column
+   * after the other. Often the column are place in this arry one right after the other
+   * but this needs not be the case: there can be unused values in the array between
+   * the values of two columns. The offset between the start of two consecutive columns
+   * in the array is called the leading dimension. For a matrix \a M with leading dimension
+   * \a ld, and data ordered in an array \a data, element M(i,j) is found at data[i+ld*j]. \n
+   * As an example, consider the matrix
+   * \f{align}{ \begin{bmatrix} 4 & 3 & 7 & 2 \\ 2 & 8 & 1 & 5 \\ 6 & 5 & 1 & 2 \end{bmatrix}
+   * \f}
+   * It can be stored with a leading dimension of 5 as \n
+   * [4, 2, 6, x, x, 3, 8, 5, x, x, 7, 1, 1, x, x, 2, 5, 2] \n
+   * where the x are unimportant value with respect to this matrix.\n
+   * For classical Eigen matrices like \a MatrixXd, ld is equal to the row size, but if for
+   * example we consider a matrix \a B that is the block of another one \a M, the
+   * leading dimension of \a B will be the row dimension of \a M.
+   */
+  EIGEN_QLD_API void problem(int nrvar, int nreq, int nrineq, int ldq = -1);
 
+  /** Return the result from the latest call to QLD::solve. */
   EIGEN_QLD_API const VectorXd & result() const;
 
-  /** Return the lagrange multipliers associated with results **/
+  /** Return the lagrange multipliers associated with results, with the multipliers
+   * corresponding to equality constraints first, then to inequality constraints, then
+   * lower bounds, then upper bounds.
+   *
+   * \warning These are the lagrange multipliers as computed by the underlying ql solver,
+   * for which the constraints have the form \f$ A_{eq} + b_{eq} = 0\f$ and
+   * \f$ A_{ineq} + b_{ineq} >= 0\f$.\n
+   * For now, QLD::solve is changing automatically the constraints, but not the multipliers.
+   */
   EIGEN_QLD_API const VectorXd & multipliers() const;
 
+  /** Solve the problem
+   * \f{align}{
+   *   \underset{{x} \in \mathbb{R}^n}{\text{minimize}} & \ \frac{1}{2}{x^TQx} + {c^Tx} \nonumber \\
+   *   \text{subject to} & \ A_{eq} x = b_{eq} \\
+   *   & \ A_{ineq} x \leq b_{ineq} \\
+   *   & \ x_l \leq x \leq x_u
+   * \f}
+   *
+   * For a positived definite matrix \f$Q\f$, we have the Cholesky decomposition \f$Q = R^T R\f$
+   * with \f$R\f$ upper triangular. If \p isDecomp is \a true, \f$R\f$ should be given instead of \f$Q\f$.
+   * Only the upper triangular part of \f$R\f$ will be used.
+   *
+   * \param Q The matrix \f$Q\f$, or its Cholesky factor \f$R\f$ if \p isDecomp is \a true.
+   * \f$Q\f$ should be symmetric and positive definite, \f$R\f$ should be upper triangular.
+   * \param c The vector \f$c\f$.
+   * \param Aeq The matrix \f$A_{eq}\f$.
+   * \param beq The vector \f$b_{eq}\f$.
+   * \param Aineq The matrix \f$A_{ineq}\f$.
+   * \param bineq The vector \f$b_{ineq}\f$.
+   * \param xl The vector \f$x_{l}\f$.
+   * \param xu The vector \f$x_{u}\f$.
+   * \param isDecomp specify if the Cholesky decomposition of \f$Q\f$ is used or not.
+   * \param eps Desired final accuracy.
+   */
   template<typename MatObj,
            typename VecObj,
            typename MatEq,
@@ -118,8 +188,6 @@ private:
   }
 };
 
-// inline
-
 template<typename MatObj,
          typename VecObj,
          typename MatEq,
@@ -128,28 +196,28 @@ template<typename MatObj,
          typename VecIneq,
          typename VecVar>
 inline bool QLD::solve(const MatrixBase<MatObj> & Q,
-                       const MatrixBase<VecObj> & C,
+                       const MatrixBase<VecObj> & c,
                        const MatrixBase<MatEq> & Aeq,
-                       const MatrixBase<VecEq> & Beq,
+                       const MatrixBase<VecEq> & beq,
                        const MatrixBase<MatIneq> & Aineq,
-                       const MatrixBase<VecIneq> & Bineq,
-                       const MatrixBase<VecVar> & XL,
-                       const MatrixBase<VecVar> & XU,
+                       const MatrixBase<VecIneq> & bineq,
+                       const MatrixBase<VecVar> & xl,
+                       const MatrixBase<VecVar> & xu,
                        bool isDecomp,
                        double eps)
 {
-  assert(Aeq.rows() == Beq.rows()); // check equality size
+  assert(Aeq.rows() == beq.rows()); // check equality size
   assert(Aeq.cols() == X_.rows());
-  assert(Aineq.rows() == Bineq.rows()); // check inequality size
+  assert(Aineq.rows() == bineq.rows()); // check inequality size
   assert(Aineq.cols() == X_.rows());
   assert(Q.rows() == Q.cols()); // check Q is square
   assert(Q.cols() == X_.rows()); // check Q has the good number of variable
-  assert(C.rows() == X_.rows()); // check C size
-  assert(XU.rows() == X_.rows()); // check XL size
-  assert(XL.rows() == X_.rows()); // check XU size
+  assert(c.rows() == X_.rows()); // check C size
+  assert(xl.rows() == X_.rows()); // check XL size
+  assert(xu.rows() == X_.rows()); // check XU size
 
-  int nreq = int(Beq.rows());
-  int nrineq = int(Bineq.rows());
+  int nreq = int(beq.rows());
+  int nrineq = int(bineq.rows());
   int nrvar = int(X_.rows());
 
   int mode = isDecomp ? 0 : 1;
@@ -158,7 +226,6 @@ inline bool QLD::solve(const MatrixBase<MatObj> & Q,
   int N = nrvar;
 
   int MMAX = int(A_.stride());
-  // beware, don't work if base Q is not square
   int NMAX = int(Q.stride());
 
   int NMN = M + 2 * N;
@@ -168,11 +235,11 @@ inline bool QLD::solve(const MatrixBase<MatObj> & Q,
   A_.block(0, 0, nreq, nrvar) = -Aeq;
   A_.block(nreq, 0, nrineq, nrvar) = -Aineq;
 
-  B_.segment(0, nreq) = Beq;
-  B_.segment(nreq, nrineq) = Bineq;
+  B_.segment(0, nreq) = beq;
+  B_.segment(nreq, nrineq) = bineq;
 
-  fortran_ql(&M, &nreq, &MMAX, &N, &NMAX, &NMN, Q.derived().data(), C.derived().data(), A_.data(), B_.data(),
-             XL.derived().data(), XU.derived().data(), X_.data(), U_.data(), &eps, &mode, &fdOut_, &fail_, &verbose_,
+  fortran_ql(&M, &nreq, &MMAX, &N, &NMAX, &NMN, Q.derived().data(), c.derived().data(), A_.data(), B_.data(),
+             xl.derived().data(), xu.derived().data(), X_.data(), U_.data(), &eps, &mode, &fdOut_, &fail_, &verbose_,
              WAR_.data(), &LWAR, IWAR_.data(), &LIWAR);
 
   return fail_ == 0;

--- a/src/eigen-qld/QLD.h
+++ b/src/eigen-qld/QLD.h
@@ -53,7 +53,7 @@ public:
   /** Create a solver and allocate the memory necessary to solve a problem with the given dimensions.
    * See also QLD::problem
    */
-  EIGEN_QLD_API QLD(int nrvar, int nreq, int nrineq, bool verbose = false, int ldq = -1);
+  EIGEN_QLD_API QLD(int nrvar, int nreq, int nrineq, int ldq = -1, bool verbose = false);
 
   /** Specify a file number for output (Fortran unit specification).*/
   EIGEN_QLD_API void fdOut(int fd);
@@ -225,12 +225,16 @@ inline bool QLD::solve(const MatrixBase<MatObj> & Q,
   int M = nreq + nrineq;
   int N = nrvar;
 
-  int MMAX = int(A_.stride());
-  int NMAX = int(Q.stride());
+  int MMAX = std::max(int(A_.stride()), 1);
+  int NMAX = std::max(int(Q.stride()), 1);
 
   int NMN = M + 2 * N;
   int LWAR = int(WAR_.rows());
   int LIWAR = int(IWAR_.rows());
+
+  assert(LWAR >= (3. * NMAX * NMAX) / 2. + 10. * NMAX + MMAX + M + 1.
+         && "Please call QLD::problem with the correct dimensions.");
+  assert(LIWAR >= N && "Please call QLD::problem with the correct dimensions.");
 
   A_.block(0, 0, nreq, nrvar) = -Aeq;
   A_.block(nreq, 0, nrineq, nrvar) = -Aineq;

--- a/src/eigen-qld/QLD.h
+++ b/src/eigen-qld/QLD.h
@@ -45,7 +45,7 @@ class QLD
 {
 public:
   EIGEN_QLD_API QLD();
-  EIGEN_QLD_API QLD(int nrvar, int nreq, int nrineq, bool verbose = false);
+  EIGEN_QLD_API QLD(int nrvar, int nreq, int nrineq, bool verbose = false, int ldq=-1, int lda=-1);
 
   EIGEN_QLD_API void fdOut(int fd);
   EIGEN_QLD_API int fdOut() const;
@@ -55,7 +55,7 @@ public:
 
   EIGEN_QLD_API int fail() const;
 
-  EIGEN_QLD_API void problem(int nrvar, int nreq, int nrineq);
+  EIGEN_QLD_API void problem(int nrvar, int nreq, int nrineq, int ldq=-1, int lda=-1);
 
   EIGEN_QLD_API const VectorXd & result() const;
 
@@ -157,9 +157,9 @@ inline bool QLD::solve(const MatrixBase<MatObj> & Q,
   int M = nreq + nrineq;
   int N = nrvar;
 
-  int MMAX = int(A_.rows());
+  int MMAX = int(A_.stride());
   // beware, don't work if base Q is not square
-  int NMAX = int(Q.rows());
+  int NMAX = int(Q.stride());
 
   int NMN = M + 2 * N;
   int LWAR = int(WAR_.rows());


### PR DESCRIPTION
The primary goal of this PR is to fix a bug appearing when the leading dimension (stride in `Eigen`) of the `Q` matrix is different from its row size.

It adds a parameter `ldq` for specifying the problem size in the constructor and the `problem` method. This parameters is added in last position and with a default value so that this won't break any client code.

The PR also add some documentation.

Remarks: 
 - for the constructor, it would make more sense to have `ldq` before `verbose`, but that would break existing codes that explicitly specify `verbose`. I wouldn't think this is frequent though.
 - the `solve` method is doing some work to assemble the constraint matrices and change some signs to reflect a difference between its convention and the native convention of QLD. It could be worth doing the same work as we did with LSSOL and have a `solve` without overhead. This might be worth opening an issue to discuss the best interface to achieve this.
 - related to this point, the returned lagrange multipliers are not in sync with the convention chosen by `solve`. For now, I put a warning. Given the low usage of lagrange multipliers, I don't know if this problem warrants opening an issue. 